### PR TITLE
Fix the wiki page links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ In old-french silogisme, greek συλλογισμός, latin syllogismos.
 
 See the following resources:
 
- - <https://en.wikipedia.org/Categorical_proposition>
- - <https://en.wikipedia.org/Syllogism>
+ - <https://en.wikipedia.org/wiki/Categorical_proposition>
+ - <https://en.wikipedia.org/wiki/Syllogism>
 
 A running instance is available on http://silogizma.org
 


### PR DESCRIPTION
When I clicked the wiki page links, it showed me this error :
![error1](https://user-images.githubusercontent.com/20958399/47258907-72aa7700-d470-11e8-8fbc-74dc25f27765.png)

I fixed the link addresses, and now it is redirecting to proper wiki pages.
![proper1](https://user-images.githubusercontent.com/20958399/47258945-f4020980-d470-11e8-8307-cdb5467af1fc.png)